### PR TITLE
Cast models left and right values to integer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 *.cache
 .DS_Store
 /.idea
+/cc-report

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Package Info:
 Build/Code Coverage:
 
 [![Tests](https://github.com/TopOnePercent/baum/actions/workflows/run_tests.yml/badge.svg?branch=master)](https://github.com/TopOnePercent/baum/actions/workflows/run_tests.yml)
-[![Coverage Status](https://img.shields.io/badge/coverage-91.56%25-brightgreen)](https://github.com/TopOnePercent/baum)
+[![Coverage Status](https://img.shields.io/badge/coverage-92.29%25-brightgreen)](https://github.com/TopOnePercent/baum)
 
 ## Nested Set implementation for Laravel
 

--- a/src/Baum/Traits/NestedSet.php
+++ b/src/Baum/Traits/NestedSet.php
@@ -1288,7 +1288,7 @@ trait NestedSet
      */
     public function destroyDescendants()
     {
-        if (is_null($this->getRight()) || is_null($this->getLeft())) {
+        if ($this->getRight() === 0 || $this->getLeft() === 0) {
             return;
         }
 
@@ -1335,7 +1335,7 @@ trait NestedSet
      */
     public function shiftSiblingsForRestore()
     {
-        if (is_null($this->getRight()) || is_null($this->getLeft())) {
+        if ($this->getRight() === 0 || $this->getLeft() === 0) {
             return;
         }
 
@@ -1361,7 +1361,7 @@ trait NestedSet
      */
     public function restoreDescendants()
     {
-        if (is_null($this->getRight()) || is_null($this->getLeft())) {
+        if ($this->getRight() === 0 || $this->getLeft() === 0) {
             return;
         }
 

--- a/src/Baum/Traits/NestedSet.php
+++ b/src/Baum/Traits/NestedSet.php
@@ -198,7 +198,7 @@ trait NestedSet
      */
     public function getLeft()
     {
-        return $this->getAttribute($this->getLeftColumnName());
+        return (int) $this->getAttribute($this->getLeftColumnName());
     }
 
     /**
@@ -228,7 +228,7 @@ trait NestedSet
      */
     public function getRight()
     {
-        return $this->getAttribute($this->getRightColumnName());
+        return (int) $this->getAttribute($this->getRightColumnName());
     }
 
     /**

--- a/tests/Main/Standard/CategoryEventsTest.php
+++ b/tests/Main/Standard/CategoryEventsTest.php
@@ -22,7 +22,6 @@ class CategoryEventsTest extends UnitAbstract
         } catch (\Exception $e) {
             $this->fail();
         }
-
     }
 
     public function testShiftsSiblingsForRestore()
@@ -35,7 +34,6 @@ class CategoryEventsTest extends UnitAbstract
         } catch (\Exception $e) {
             $this->fail();
         }
-
     }
 
     public function testRestoresDescendants()
@@ -48,6 +46,5 @@ class CategoryEventsTest extends UnitAbstract
         } catch (\Exception $e) {
             $this->fail();
         }
-
     }
 }

--- a/tests/Main/Standard/CategoryEventsTest.php
+++ b/tests/Main/Standard/CategoryEventsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Baum\Tests\Main\Standard;
+
+use Baum\Tests\Main\Concerns\NodeModelExtensionsTestTrait;
+use Baum\Tests\Main\Models\Category;
+use Baum\Tests\Main\Support\PopulateData;
+use Baum\Tests\Main\UnitAbstract;
+use Illuminate\Support\Facades\Event;
+
+class CategoryEventsTest extends UnitAbstract
+{
+    use NodeModelExtensionsTestTrait;
+
+    public function testDeletesNode()
+    {
+        $node = new Category();
+
+        try {
+            $node->destroyDescendants();
+            $this->assertTrue(true);
+        } catch (\Exception $e) {
+            $this->fail();
+        }
+
+    }
+
+    public function testShiftsSiblingsForRestore()
+    {
+        $node = new Category();
+
+        try {
+            $node->shiftSiblingsForRestore();
+            $this->assertTrue(true);
+        } catch (\Exception $e) {
+            $this->fail();
+        }
+
+    }
+
+    public function testRestoresDescendants()
+    {
+        $node = new Category();
+
+        try {
+            $node->restoreDescendants();
+            $this->assertTrue(true);
+        } catch (\Exception $e) {
+            $this->fail();
+        }
+
+    }
+}


### PR DESCRIPTION
In situations where model doesn't have any records in database getLeft() and getRight() methods in NestedSet trait return 'null'  which can cause problems in Laravel query builder. This fix makes sure that the returned value is cast to integer.